### PR TITLE
Configure Git LFS for binary assets

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,16 +1,20 @@
 # Set default behavior to automatically normalize line endings.
 * text=auto
-
 # Force bash scripts to always use LF line endings so that if a repo is accessed
 # in Unix via a file share from Windows, the scripts will work.
 *.sh text eol=lf
-
 # Force batch scripts to always use CRLF line endings so that if a repo is accessed
 # in Windows via a file share from Linux, the scripts will work.
 *.{cmd,[cC][mM][dD]} text eol=crlf
 *.{bat,[bB][aA][tT]} text eol=crlf
-
-# Denote all files that are truly binary and should not be modified.
-*.png binary
-*.jpg binary
-*.ico binary
+# Store binary assets in Git LFS.
+*.png  filter=lfs diff=lfs merge=lfs -text
+*.jpg  filter=lfs diff=lfs merge=lfs -text
+*.jpeg filter=lfs diff=lfs merge=lfs -text
+*.gif  filter=lfs diff=lfs merge=lfs -text
+*.webp filter=lfs diff=lfs merge=lfs -text
+*.ico  filter=lfs diff=lfs merge=lfs -text
+*.mp4  filter=lfs diff=lfs merge=lfs -text
+*.mov  filter=lfs diff=lfs merge=lfs -text
+*.webm filter=lfs diff=lfs merge=lfs -text
+*.pdf  filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -31,6 +31,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          lfs: true
           # submodules: true
           # If using the 'assets' git submodule from Chirpy Starter, uncomment above
           # (See: https://github.com/cotes2020/chirpy-starter/tree/main/assets)


### PR DESCRIPTION
## Summary

- `.gitattributes`: `*.png / .jpg / .jpeg / .gif / .webp / .ico / .mp4 / .mov / .webm / .pdf` を `binary` 属性から Git LFS 管理（`filter=lfs diff=lfs merge=lfs -text`）に変更
- `.github/workflows/pages-deploy.yml`: checkout ステップに `lfs: true` を追加し、CI ビルド時に LFS オブジェクトを取得できるように設定

既存のコミット済み画像（favicons、avatar など）は通常の git blob のまま。今後追加するファイルから自動的に LFS へ格納される。

## Test plan

- [ ] CI (Build and Deploy) が正常に完了すること
- [ ] 新規画像を `git add` したとき `git lfs ls-files` にリストされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)