### PR TITLE
Add VS Marketplace publisher page, privacy policy, and site links

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,0 +1,47 @@
+<!-- The Footer -->
+
+<footer
+  aria-label="Site Info"
+  class="
+    d-flex flex-column justify-content-center text-muted
+    flex-lg-row justify-content-lg-between align-items-lg-center pb-lg-3
+  "
+>
+  <p>
+    {{- '©' }}
+    <time>{{ 'now' | date: '%Y' }}</time>
+
+    {% if site.social.links %}
+      <a href="{{ site.social.links[0] }}">{{ site.social.name }}</a>.
+    {% else %}
+      <em class="fst-normal">{{ site.social.name }}</em>.
+    {% endif %}
+
+    {% if site.data.locales[include.lang].copyright.brief %}
+      <span
+        data-bs-toggle="tooltip"
+        data-bs-placement="top"
+        title="{{ site.data.locales[include.lang].copyright.verbose }}"
+      >
+        {{- site.data.locales[include.lang].copyright.brief -}}
+      </span>
+    {% endif %}
+  </p>
+
+  <p>
+    VS Code Extension Publisher:
+    <a href="/extensions/" rel="noopener">long-kudo</a>
+  </p>
+
+  <p>
+    {%- capture _platform -%}
+      <a href="https://jekyllrb.com" target="_blank" rel="noopener">Jekyll</a>
+    {%- endcapture -%}
+
+    {%- capture _theme -%}
+      <a href="https://github.com/cotes2020/jekyll-theme-chirpy" target="_blank" rel="noopener">Chirpy</a>
+    {%- endcapture -%}
+
+    {{ site.data.locales[include.lang].meta | replace: ':PLATFORM', _platform | replace: ':THEME', _theme }}
+  </p>
+</footer>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -1,0 +1,124 @@
+---
+layout: default
+refactor: true
+---
+
+{% include lang.html %}
+
+{% assign pinned = site.posts | where: 'pin', 'true' %}
+{% assign default = site.posts | where_exp: 'item', 'item.pin != true and item.hidden != true' %}
+
+{% assign posts = '' | split: '' %}
+
+<!-- Get pinned posts -->
+
+{% assign offset = paginator.page | minus: 1 | times: paginator.per_page %}
+{% assign pinned_num = pinned.size | minus: offset %}
+
+{% if pinned_num > 0 %}
+  {% for i in (offset..pinned.size) limit: pinned_num %}
+    {% assign posts = posts | push: pinned[i] %}
+  {% endfor %}
+{% else %}
+  {% assign pinned_num = 0 %}
+{% endif %}
+
+<!-- Get default posts -->
+
+{% assign default_beg = offset | minus: pinned.size %}
+
+{% if default_beg < 0 %}
+  {% assign default_beg = 0 %}
+{% endif %}
+
+{% assign default_num = paginator.posts | size | minus: pinned_num %}
+{% assign default_end = default_beg | plus: default_num | minus: 1 %}
+
+{% if default_num > 0 %}
+  {% for i in (default_beg..default_end) %}
+    {% assign posts = posts | push: default[i] %}
+  {% endfor %}
+{% endif %}
+
+<p class="ps-1 text-muted" style="font-size:.85rem">
+  <i class="fas fa-puzzle-piece fa-fw me-1"></i>
+  VS Code Extensions by long-kudo &rarr;
+  <a href="/extensions/">910.jp/extensions</a>
+</p>
+
+<div id="post-list" class="flex-grow-1 px-xl-1">
+  {% for post in posts %}
+    <article class="card-wrapper card">
+      <a href="{{ post.url | relative_url }}" class="post-preview row g-0 flex-md-row-reverse">
+        {% assign card_body_col = '12' %}
+
+        {% if post.image %}
+          {% assign src = post.image.path | default: post.image %}
+          {% unless src contains '//' %}
+            {% assign src = post.img_path | append: '/' | append: src | replace: '//', '/' %}
+          {% endunless %}
+
+          {% assign alt = post.image.alt | xml_escape | default: 'Preview Image' %}
+
+          {% assign lqip = null %}
+
+          {% if post.image.lqip %}
+            {% capture lqip %}lqip="{{ post.image.lqip }}"{% endcapture %}
+          {% endif %}
+
+          <div class="col-md-5">
+            <img src="{{ src }}" alt="{{ alt }}" {{ lqip }}>
+          </div>
+
+          {% assign card_body_col = '7' %}
+        {% endif %}
+
+        <div class="col-md-{{ card_body_col }}">
+          <div class="card-body d-flex flex-column">
+            <h1 class="card-title my-2 mt-md-0">{{ post.title }}</h1>
+
+            <div class="card-text content mt-0 mb-3">
+              <p>
+                {% include no-linenos.html content=post.content %}
+                {{ content | markdownify | strip_html | truncate: 200 | escape }}
+              </p>
+            </div>
+
+            <div class="post-meta flex-grow-1 d-flex align-items-end">
+              <div class="me-auto">
+                <!-- posted date -->
+                <i class="far fa-calendar fa-fw me-1"></i>
+                {% include datetime.html date=post.date lang=lang %}
+
+                <!-- categories -->
+                {% if post.categories.size > 0 %}
+                  <i class="far fa-folder-open fa-fw me-1"></i>
+                  <span class="categories">
+                    {% for category in post.categories %}
+                      {{ category }}
+                      {%- unless forloop.last -%},{%- endunless -%}
+                    {% endfor %}
+                  </span>
+                {% endif %}
+              </div>
+
+              {% if post.pin %}
+                <div class="pin ms-1">
+                  <i class="fas fa-thumbtack fa-fw"></i>
+                  <span>{{ site.data.locales[lang].post.pin_prompt }}</span>
+                </div>
+              {% endif %}
+            </div>
+            <!-- .post-meta -->
+          </div>
+          <!-- .card-body -->
+        </div>
+      </a>
+    </article>
+  {% endfor %}
+</div>
+<!-- #post-list -->
+
+{% if paginator.total_pages > 1 %}
+  {% include post-paginator.html %}
+{% endif %}

--- a/_posts/2026-02-28-official-extensions.md
+++ b/_posts/2026-02-28-official-extensions.md
@@ -1,0 +1,32 @@
+---
+title: "VS Code Extensions by long-kudo"
+date: 2026-02-28 00:00:00 +0900
+categories: [Announcement]
+tags: [vscode, extension, claude, charset]
+pin: true
+image:
+  path: https://upload.wikimedia.org/wikipedia/commons/9/9a/Visual_Studio_Code_1.35_icon.svg
+  width: 400
+  height: 400
+  alt: VS Code
+---
+
+We publish lightweight, productivity-focused extensions for Visual Studio Code under the publisher account **long-kudo**.
+
+## Our Extensions
+
+### [VSCode Claude Status](https://marketplace.visualstudio.com/items?itemName=long-kudo.vscode-claude-status)
+
+Displays your Claude AI session status directly in the VS Code status bar.
+Stay informed about your Claude connection state without switching windows.
+
+### [VSCode View Charset](https://marketplace.visualstudio.com/items?itemName=long-kudo.vscode-view-charset)
+
+Shows the character encoding of the currently open file in the status bar.
+Essential for multilingual projects and debugging encoding issues in legacy codebases.
+
+---
+
+For full details including installation instructions, see the [Extensions page](/extensions/).
+
+Publisher page: [marketplace.visualstudio.com/publishers/long-kudo](https://marketplace.visualstudio.com/publishers/long-kudo)

--- a/_tabs/extensions.md
+++ b/_tabs/extensions.md
@@ -1,0 +1,187 @@
+---
+title: VS Code Extensions
+icon: fas fa-plug
+order: 6
+description: VS Code extensions by long-kudo — Claude Status and View Charset.
+---
+
+<div id="lang-switch" style="margin-bottom:1.5rem">
+  <button id="btn-en" onclick="switchLang('en')" style="margin-right:.5rem;padding:.3rem .8rem;border-radius:4px;border:2px solid;cursor:pointer">🇺🇸 English</button>
+  <button id="btn-ja" onclick="switchLang('ja')" style="padding:.3rem .8rem;border-radius:4px;border:1px solid;cursor:pointer">🇯🇵 日本語</button>
+</div>
+
+<div id="content-en" class="lang-content" markdown="1">
+
+This is the official website of VS Code publisher **long-kudo**.
+
+[View all extensions on Visual Studio Marketplace →](https://marketplace.visualstudio.com/publishers/long-kudo)
+
+---
+
+## VSCode Claude Status
+
+**[Install on Marketplace](https://marketplace.visualstudio.com/items?itemName=long-kudo.vscode-claude-status)**
+
+**VSCode Claude Status** displays your Claude AI session status directly in the VS Code status bar, so you can monitor your connection state without leaving the editor.
+
+<img src="/assets/img/extensions/claude-status-webview.png"
+     alt="VSCode Claude Status — WebView panel showing Claude session details"
+     style="max-width:100%;border-radius:6px;box-shadow:0 2px 10px rgba(0,0,0,.2);margin:1rem 0 .5rem"
+     onerror="this.style.display='none'">
+
+<img src="/assets/img/extensions/claude-status-statusbar.png"
+     alt="VSCode Claude Status — Claude session status shown in the VS Code status bar"
+     style="max-width:100%;border-radius:6px;box-shadow:0 2px 10px rgba(0,0,0,.2);margin:.5rem 0 1rem"
+     onerror="this.style.display='none'">
+
+### Features
+
+- Displays Claude session status in the VS Code status bar
+- Updates in real time as your session changes
+- Lightweight — minimal resource usage
+- No unnecessary permissions required
+
+### How to Install and Use
+
+1. Open VS Code and go to the Extensions panel (`Ctrl+Shift+X`)
+2. Search for **"Claude Status"** or open the [Marketplace page](https://marketplace.visualstudio.com/items?itemName=long-kudo.vscode-claude-status) directly
+3. Click **Install**
+4. The Claude status indicator will appear automatically in the status bar
+
+---
+
+## VSCode View Charset
+
+**[Install on Marketplace](https://marketplace.visualstudio.com/items?itemName=long-kudo.vscode-view-charset)**
+
+**VSCode View Charset** shows the character encoding of the currently open file in the VS Code status bar. Essential for multilingual projects and legacy codebases where encoding issues are common.
+
+<img src="/assets/img/extensions/view-charset.png"
+     alt="VSCode View Charset — file encoding shown in the VS Code status bar"
+     style="max-width:100%;border-radius:6px;box-shadow:0 2px 10px rgba(0,0,0,.2);margin:1rem 0"
+     onerror="this.style.display='none'">
+
+### Features
+
+- Detects and displays file encoding (charset) in the status bar
+- Supports many encodings including UTF-8, Shift-JIS, EUC-JP, and others
+- Zero configuration — works out of the box
+- Lightweight and fast
+
+### How to Install and Use
+
+1. Open VS Code and go to the Extensions panel (`Ctrl+Shift+X`)
+2. Search for **"View Charset"** or open the [Marketplace page](https://marketplace.visualstudio.com/items?itemName=long-kudo.vscode-view-charset) directly
+3. Click **Install**
+4. Open any file — the character encoding will appear automatically in the status bar
+
+---
+
+## About the Publisher
+
+| | |
+|---|---|
+| Publisher | **long-kudo** |
+| Official site | [https://910.jp](https://910.jp) |
+| Marketplace | [marketplace.visualstudio.com/publishers/long-kudo](https://marketplace.visualstudio.com/publishers/long-kudo) |
+| Privacy Policy | [/privacy-policy/](/privacy-policy/) |
+
+</div>
+
+<div id="content-ja" class="lang-content" style="display:none" markdown="1">
+
+本サイト（https://910.jp）は、VS Code publisher **long-kudo** の公式サイトです。
+
+[Visual Studio Marketplace で全拡張機能を見る →](https://marketplace.visualstudio.com/publishers/long-kudo)
+
+---
+
+## VSCode Claude Status
+
+**[Marketplace からインストール](https://marketplace.visualstudio.com/items?itemName=long-kudo.vscode-claude-status)**
+
+**VSCode Claude Status** は、Claude AI のセッション状態を VS Code のステータスバーに表示する軽量拡張機能です。エディタを離れることなく、Claude の接続状態をリアルタイムで確認できます。
+
+<img src="/assets/img/extensions/claude-status-webview.png"
+     alt="VSCode Claude Status — Claude セッション詳細を表示する WebView パネル"
+     style="max-width:100%;border-radius:6px;box-shadow:0 2px 10px rgba(0,0,0,.2);margin:1rem 0 .5rem"
+     onerror="this.style.display='none'">
+
+<img src="/assets/img/extensions/claude-status-statusbar.png"
+     alt="VSCode Claude Status — VS Code ステータスバーに Claude の状態を表示"
+     style="max-width:100%;border-radius:6px;box-shadow:0 2px 10px rgba(0,0,0,.2);margin:.5rem 0 1rem"
+     onerror="this.style.display='none'">
+
+### 主な機能
+
+- Claude のセッション状態をステータスバーに表示
+- リアルタイムで状態を更新
+- 軽量・低リソース使用
+- 不要なパーミッション不要
+
+### インストールと使い方
+
+1. VS Code の拡張機能パネル（`Ctrl+Shift+X`）を開く
+2. **「Claude Status」** で検索するか、[Marketplace ページ](https://marketplace.visualstudio.com/items?itemName=long-kudo.vscode-claude-status) を直接開く
+3. **インストール** をクリック
+4. ステータスバーに Claude の状態が自動的に表示されます
+
+---
+
+## VSCode View Charset
+
+**[Marketplace からインストール](https://marketplace.visualstudio.com/items?itemName=long-kudo.vscode-view-charset)**
+
+**VSCode View Charset** は、現在開いているファイルの文字コード（エンコーディング）を VS Code のステータスバーに表示する拡張機能です。多言語プロジェクトやレガシーシステムでの文字化け調査に役立ちます。
+
+<img src="/assets/img/extensions/view-charset.png"
+     alt="VSCode View Charset — VS Code ステータスバーにファイルの文字コードを表示"
+     style="max-width:100%;border-radius:6px;box-shadow:0 2px 10px rgba(0,0,0,.2);margin:1rem 0"
+     onerror="this.style.display='none'">
+
+### 主な機能
+
+- ファイルの文字コードをステータスバーに表示
+- UTF-8、Shift-JIS、EUC-JP など多数のエンコーディングに対応
+- 設定不要 — インストールするだけで動作
+- 軽量・高速
+
+### インストールと使い方
+
+1. VS Code の拡張機能パネル（`Ctrl+Shift+X`）を開く
+2. **「View Charset」** で検索するか、[Marketplace ページ](https://marketplace.visualstudio.com/items?itemName=long-kudo.vscode-view-charset) を直接開く
+3. **インストール** をクリック
+4. ファイルを開くと、文字コードが自動的にステータスバーに表示されます
+
+---
+
+## Publisher 情報
+
+| | |
+|---|---|
+| Publisher | **long-kudo** |
+| 公式サイト | [https://910.jp](https://910.jp) |
+| Marketplace | [marketplace.visualstudio.com/publishers/long-kudo](https://marketplace.visualstudio.com/publishers/long-kudo) |
+| プライバシーポリシー | [/privacy-policy/](/privacy-policy/) |
+
+</div>
+
+<script>
+function switchLang(lang) {
+  document.querySelectorAll('.lang-content').forEach(function(el) {
+    el.style.display = 'none';
+  });
+  document.getElementById('content-' + lang).style.display = 'block';
+  document.getElementById('btn-en').style.borderWidth = lang === 'en' ? '2px' : '1px';
+  document.getElementById('btn-en').style.fontWeight  = lang === 'en' ? 'bold' : 'normal';
+  document.getElementById('btn-ja').style.borderWidth = lang === 'ja' ? '2px' : '1px';
+  document.getElementById('btn-ja').style.fontWeight  = lang === 'ja' ? 'bold' : 'normal';
+  try { localStorage.setItem('extLang', lang); } catch(e) {}
+}
+(function() {
+  var saved = '';
+  try { saved = localStorage.getItem('extLang'); } catch(e) {}
+  var lang = saved || (navigator.language && navigator.language.startsWith('ja') ? 'ja' : 'en');
+  switchLang(lang);
+})();
+</script>

--- a/_tabs/privacy-policy.md
+++ b/_tabs/privacy-policy.md
@@ -1,0 +1,37 @@
+---
+title: Privacy Policy
+icon: fas fa-shield-alt
+order: 7
+---
+
+_Last updated: 2026-02-28_
+
+This Privacy Policy describes how this website (https://910.jp) and the VS Code extensions published by **long-kudo** handle your information.
+
+---
+
+## VS Code Extensions
+
+The VS Code extensions published by long-kudo — **VSCode Claude Status** and **VSCode View Charset** — do not collect, store, or transmit any personal data.
+
+- No personal information is collected.
+- No usage analytics or telemetry are sent from within the extensions.
+- No external API calls are made, except for the minimum required for the extension's core functionality (e.g., reading local VS Code session state).
+
+---
+
+## This Website
+
+**Analytics**
+
+This website uses [Google Analytics](https://marketingplatform.google.com/about/analytics/) to collect anonymized usage statistics (page views, referrers, device type). This data is used solely to understand site traffic and improve content. No personally identifiable information is collected. You can opt out via [Google Analytics Opt-out](https://tools.google.com/dlpage/gaoptout).
+
+**Comments**
+
+Posts on this site use [utterances](https://utteranc.es/) for comments, which are stored as GitHub Issues. Leaving a comment requires authentication via GitHub. Please refer to [GitHub's Privacy Statement](https://docs.github.com/en/site-policy/privacy-policies/github-privacy-statement) for details on how GitHub handles your data.
+
+---
+
+## Contact
+
+If you have any questions about this privacy policy, please contact via [GitHub](https://github.com/long-910).

--- a/assets/img/extensions/claude-status-statusbar.png
+++ b/assets/img/extensions/claude-status-statusbar.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d029157794c7d5ec333c92eb87eb3551c111cf067f171598c479fec8094ef6e
+size 9621

--- a/assets/img/extensions/claude-status-webview.png
+++ b/assets/img/extensions/claude-status-webview.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fa096ad4b2af4fc25520f5acff3799c6a4a2767ee9d9606ad702801d9bf6085e
+size 116733


### PR DESCRIPTION
## Summary

VS Marketplace のパブリッシャー認証対応として追加したコンテンツ一式。

- **`_tabs/extensions.md`**: EN/JA バイリンガル対応の拡張機能ページ（JS 言語トグル・localStorage 永続化・スクリーンショット付き）
- **`_tabs/privacy-policy.md`**: プライバシーポリシー（GA4・utterances 記載）
- **`_posts/2026-02-28-official-extensions.md`**: ピン固定のアナウンス投稿
- **`_layouts/home.html`**: ホームページ上部に Extensions への小リンクを追加
- **`_includes/footer.html`**: フッターに "VS Code Extension Publisher: long-kudo" を追加
- **`assets/img/extensions/`**: Claude Status スクリーンショット 2 枚（Git LFS 管理）

## Test plan

- [ ] CI (Build and Deploy) が正常完了すること
- [ ] `/extensions/` ページで EN/JA 切り替えが動作すること
- [ ] `/privacy-policy/` ページが表示されること
- [ ] ホームページ上部リンク・フッターリンクが正しく `/extensions/` へ遷移すること
- [ ] スクリーンショットがページに表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)